### PR TITLE
Full support for Active Choices Plug-in

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,8 @@ Example:
 
 .. code-block:: yaml
 
+    # OLD: partial support of Active Choice Plug-in capabilities
+    # deprecated -- see below
     - job:
         name: 'cascade-choice-example'
 
@@ -41,6 +43,76 @@ Example:
               reference: STR_PARAM
               omit-value: false
               choice-type: bullet-list
+
+    # NEW: Supports full capabilities of the Active Choice Plug-in
+    - job:
+        name: 'TEST-jjb-active-choice-full-support'
+  
+        parameters:
+            - string:
+                name: STR_PARAM
+                default: test
+  
+            - choice:
+                name: CHOICE_PARAM
+                choices:
+                  - choice_01
+                  - choice_02
+                  - choice_03
+                  - choice_04
+                description: |
+                  Just a test parameter for used by references
+  
+            - active-choice:
+                project: 'active-choice-example'
+                name: ACTIVE_CHOICE_01
+                description: "A parameter named ACTIVE_CHOICE_01 with options foo and bar."
+                groovy:
+                    script: |
+                        return ['foo:selected', 'bar']
+                    classpath: file:/tmp/aklsdjfkl.jar
+                    sandbox: false        
+                fallback:
+                    script: |
+                        return ['Error']
+                visible-item-count: 1
+                choice-type: single
+                filterable:  true
+                filter-length: 3
+  
+            - active-choice-reactive:
+                project: 'active-choice-example'
+                name: ACTIVE_CHOICE_REACTIVE_01
+                description: "A parameter named ACTIVE_CHOICE_REACTIVE_01 with options foo and bar."
+                groovy:
+                    script: |
+                        return ['foo:selected', 'bar']
+                    classpath: file:/tmp/aklsdjfkl.jar
+                fallback:
+                    script: |
+                        return ['Error']
+                    classpath: file:/tmp/aklsdjfkl.jar,https://lakjsdfklsdjklf/lkajsdflk.jar
+                    sandbox: true    
+                visible-item-count: 10
+                reference: STR_PARAM,CHOICE_PARAM
+                choice-type: multi
+  
+            - active-choice-reactive-reference:
+                name: ACTIVE_CHOICE_REACTIVE_REF_01
+                project: 'active-choice-example'
+                description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_01 with options foo and bar."
+                groovy:
+                    script: |
+                        return ['foo:selected', 'bar']
+                    classpath: file:/tmp/aklsdjfkl.jar
+                    sandbox: true    
+                fallback:
+                    script: |
+                        return ['Error']
+                    classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+                reference: STR_PARAM,CHOICE_PARAM
+                omit-value: false
+                choice-type: bullet-list
 
 
 .. _`Active Choice Plugin`: https://wiki.jenkins-ci.org/display/JENKINS/Active+Choices+Plugin

--- a/dev-files/README.md
+++ b/dev-files/README.md
@@ -1,0 +1,2 @@
+
+# Just a few files used to during dev/test of the full support for the Active Choice plug-in

--- a/dev-files/dev.yml
+++ b/dev-files/dev.yml
@@ -1,244 +1,258 @@
-- job:
-    name: 'active-choice-example'
+  - job:
+      name: 'TEST-jjb-active-choice'
 
-    parameters:
-      - string:
-          name: STR_PARAM
-          default: test
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
 
-      - active-choice:
-          project: 'active-choice-example'
-          name: ACTIVE_CHOICE_01
-          description: "A parameter named ACTIVE_CHOICE_01 with options foo and bar."
-          groovy:
-              script: |
-                  return ['foo:selected', 'bar']
-              classpath: file:/tmp/aklsdjfkl.jar
-              sandbox: false        
-          fallback:
-              script: |
-                  return ['Error']
-          visible-item-count: 1
-          choice-type: single
-          filterable:  true
-          filter-length: 1
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
 
-      - active-choice:
-          project: 'active-choice-example'
-          name: ACTIVE_CHOICE_02
-          description: "A parameter named ACTIVE_CHOICE_02 with options foo and bar."
-          groovy:
-              script: |
-                  return ['foo:selected', 'bar']
-          fallback:
-              script: |
-                  return ['Error']
-              sandbox: true    
-              classpath: file:/tmp/aklsdjfkl.jar
-          visible-item-count: 1
-          choice-type: multi
-          filterable:  false
+          - active-choice:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_01
+              description: "A parameter named ACTIVE_CHOICE_01 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+                  sandbox: false        
+              fallback:
+                  script: |
+                      return ['Error']
+              visible-item-count: 1
+              choice-type: single
+              filterable:  true
+              filter-length: 3
 
-      - active-choice:
-          project: 'active-choice-example'
-          name: ACTIVE_CHOICE_03
-          description: "A parameter named ACTIVE_CHOICE_03 with options foo and bar."
-          groovy:
-              script: |
-                  return ['foo:selected', 'bar']
-          fallback:
-              script: |
-                  return ['Error']
-              sandbox: true    
-              classpath: file:/tmp/aklsdjfkl.jar
-          visible-item-count: 1
-          choice-type: radio
+          - active-choice:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_02
+              description: "A parameter named ACTIVE_CHOICE_02 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+              fallback:
+                  script: |
+                      return ['Error']
+                  sandbox: true    
+                  classpath: file:/tmp/aklsdjfkl.jar
+              visible-item-count: 4
+              choice-type: multi
+              filterable:  false
 
-      - active-choice:
-          project: 'active-choice-example'
-          name: ACTIVE_CHOICE_04
-          description: "A parameter named ACTIVE_CHOICE_04 with options foo and bar."
-          groovy:
-              script: |
-                  return ['foo:selected', 'bar']
-          fallback:
-              script: |
-                  return ['Error']
-              sandbox: true    
-              classpath: file:/tmp/aklsdjfkl.jar
-          visible-item-count: 1
-          choice-type: checkbox
+          - active-choice:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_03
+              description: "A parameter named ACTIVE_CHOICE_03 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+              fallback:
+                  script: |
+                      return ['Error']
+                  sandbox: true    
+                  classpath: file:/tmp/aklsdjfkl.jar
+              visible-item-count: 3
+              choice-type: radio
 
-      - active-choice:
-          project: 'active-choice-example'
-          name: ACTIVE_CHOICE_05
-          description: "A parameter named ACTIVE_CHOICE_05 with options foo and bar."
-          scriptler:
-              script: print-path
-              parameters:
-                  - PARAM1:  value1 alksdjflksdf lkasjflk
-                  - PARAM2:  value2
-          visible-item-count: 1
-          choice-type: checkbox
+          - active-choice:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_04
+              description: "A parameter named ACTIVE_CHOICE_04 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+              fallback:
+                  script: |
+                      return ['Error']
+                  sandbox: true    
+                  classpath: file:/tmp/aklsdjfkl.jar
+              visible-item-count: 1
+              choice-type: checkbox
 
-      - active-choice-reactive:
-          project: 'active-choice-example'
-          name: ACTIVE_CHOICE_REACTIVE_01
-          description: "A parameter named ACTIVE_CHOICE_REACTIVE_01 with options foo and bar."
-          groovy:
-              script: |
-                  return ['foo:selected', 'bar']
-              classpath: file:/tmp/aklsdjfkl.jar
-          fallback:
-              script: |
-                  return ['Error']
-              classpath: file:/tmp/aklsdjfkl.jar,https://lakjsdfklsdjklf/lkajsdflk.jar
-              sandbox: true    
-          visible-item-count: 10
-          reference: STR_PARAM
-          choice-type: multi
+          - active-choice:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_05
+              description: "A parameter named ACTIVE_CHOICE_05 with options foo and bar."
+              scriptler:
+                  script: print-path
+                  parameters:
+                      - PARAM1:  value1 alksdjflksdf lkasjflk
+                      - PARAM2:  value2
+              visible-item-count: 1
+              choice-type: checkbox
 
-      - active-choice-reactive:
-          project: 'active-choice-example'
-          name: ACTIVE_CHOICE_REACTIVE_02
-          description: "A parameter named ACTIVE_CHOICE_REACTIVE_02 with options foo and bar."
-          groovy:
-              script: |
-                  return ['foo:selected', 'bar']
-              classpath: file:/your-path/your-classes.jar
-              sandbox: true    
-          reference: STR_PARAM,ACTIVE_CHOICE_01
-          visible-item-count: 10
-          choice-type: radio
-          filterable:  true
-          filter-length:  1
+          - active-choice-reactive:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_01
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_01 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,https://lakjsdfklsdjklf/lkajsdflk.jar
+                  sandbox: true    
+              visible-item-count: 10
+              reference: STR_PARAM,CHOICE_PARAM
+              choice-type: multi
 
-      - active-choice-reactive:
-          project: 'active-choice-example'
-          name: ACTIVE_CHOICE_REACTIVE_03
-          description: "A parameter named ACTIVE_CHOICE_REACTIVE_03 with options foo and bar."
-          scriptler:
-              script: print-path
-              parameters:
-                  - PARAM1:  value1 aklfsdj kalsjflk
-                  - PARAM2:  value2
-          reference: STR_PARAM
-          visible-item-count: 10
-          choice-type: checkbox
+          - active-choice-reactive:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_02
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_02 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/your-path/your-classes.jar
+                  sandbox: true    
+              reference: STR_PARAM,ACTIVE_CHOICE_01
+              visible-item-count: 10
+              choice-type: radio
+              filterable:  true
+              filter-length:  10
 
-      - active-choice-reactive:
-          project: 'active-choice-example'
-          name: ACTIVE_CHOICE_REACTIVE_04
-          description: "A parameter named ACTIVE_CHOICE_REACTIVE_04 with options foo and bar."
-          scriptler:
-              script: print-path
-          reference: STR_PARAM
-          visible-item-count: 10
-          choice-type: checkbox
+          - active-choice-reactive:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_03
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_03 with options foo and bar."
+              scriptler:
+                  script: print-path
+                  parameters:
+                      - PARAM1:  value1 aklfsdj kalsjflk
+                      - PARAM2:  value2
+              reference: STR_PARAM
+              visible-item-count: 10
+              choice-type: checkbox
+              filterable:  true
+              filter-length: 4
 
-      - active-choice-reactive-reference:
-          name: ACTIVE_CHOICE_REACTIVE_REF_01
-          project: 'active-choice-example'
-          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_01 with options foo and bar."
-          groovy:
-              script: |
-                  return ['foo:selected', 'bar']
-              classpath: file:/tmp/aklsdjfkl.jar
-              sandbox: true    
-          fallback:
-              script: |
-                  return ['Error']
-              classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
-          reference: STR_PARAM
-          omit-value: false
-          choice-type: input-text
+          - active-choice-reactive:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_04
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_04 with options foo and bar."
+              scriptler:
+                  script: print-path
+              reference: STR_PARAM,CHOICE_PARAM
+              visible-item-count: 10
+              choice-type: checkbox
 
-      - active-choice-reactive-reference:
-          name: ACTIVE_CHOICE_REACTIVE_REF_02
-          project: 'active-choice-example'
-          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_02 with options foo and bar."
-          groovy:
-              script: |
-                  return ['foo:selected', 'bar']
-              classpath: file:/tmp/aklsdjfkl.jar
-              sandbox: true    
-          fallback:
-              script: |
-                  return ['Error']
-              classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
-          reference: STR_PARAM,ACTIVE_CHOICE_01
-          omit-value: false
-          choice-type: numbered-list
+          - active-choice-reactive-reference:
+              name: ACTIVE_CHOICE_REACTIVE_REF_01
+              project: 'active-choice-example'
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_01 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+                  sandbox: true    
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              reference: STR_PARAM
+              omit-value: false
+              choice-type: input-text
 
-      - active-choice-reactive-reference:
-          name: ACTIVE_CHOICE_REACTIVE_REF_03
-          project: 'active-choice-example'
-          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_03 with options foo and bar."
-          groovy:
-              script: |
-                  return ['foo:selected', 'bar']
-              classpath: file:/tmp/aklsdjfkl.jar
-              sandbox: true    
-          fallback:
-              script: |
-                  return ['Error']
-              classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
-          reference: STR_PARAM
-          omit-value: false
-          choice-type: bullet-list
+          - active-choice-reactive-reference:
+              name: ACTIVE_CHOICE_REACTIVE_REF_02
+              project: 'active-choice-example'
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_02 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+                  sandbox: true    
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              reference: STR_PARAM,ACTIVE_CHOICE_01
+              omit-value: false
+              choice-type: numbered-list
 
-      - active-choice-reactive-reference:
-          name: ACTIVE_CHOICE_REACTIVE_REF_04
-          project: 'active-choice-example'
-          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_04 with options foo and bar."
-          groovy:
-              script: |
-                  return ['foo:selected', 'bar']
-              classpath: file:/tmp/aklsdjfkl.jar
-              sandbox: true    
-          fallback:
-              script: |
-                  return ['Error']
-              classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
-          reference: STR_PARAM
-          omit-value: false
-          choice-type: formatted-html
+          - active-choice-reactive-reference:
+              name: ACTIVE_CHOICE_REACTIVE_REF_03
+              project: 'active-choice-example'
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_03 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+                  sandbox: true    
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              reference: STR_PARAM,CHOICE_PARAM
+              omit-value: false
+              choice-type: bullet-list
 
-      - active-choice-reactive-reference:
-          name: ACTIVE_CHOICE_REACTIVE_REF_05
-          project: 'active-choice-example'
-          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_05 with options foo and bar."
-          groovy:
-              script: |
-                  return ['foo:selected', 'bar']
-              sandbox: true    
-          fallback:
-              script: |
-                  return ['Error']
-              classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
-          reference: STR_PARAM
-          omit-value: false
-          choice-type: formatted-hidden-html
+          - active-choice-reactive-reference:
+              name: ACTIVE_CHOICE_REACTIVE_REF_04
+              project: 'active-choice-example'
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_04 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+                  sandbox: true    
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              reference: STR_PARAM,CHOICE_PARAM
+              omit-value: false
+              choice-type: formatted-html
 
-      - active-choice-reactive-reference:
-          project: 'active-choice-example'
-          name: ACTIVE_CHOICE_REACTIVE_REF_06
-          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_06 with options foo and bar."
-          scriptler:
-              script: print-path
-              parameters:
-                  - PARAM1: value1
-          reference: STR_PARAM
-          visible-item-count: 10
-          choice-type: input-text 
+          - active-choice-reactive-reference:
+              name: ACTIVE_CHOICE_REACTIVE_REF_05
+              project: 'active-choice-example'
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_05 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  sandbox: true    
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              reference: STR_PARAM
+              omit-value: false
+              choice-type: formatted-hidden-html
 
-      - active-choice-reactive-reference:
-          project: 'active-choice-example'
-          name: ACTIVE_CHOICE_REACTIVE_REF_07
-          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_07 with options foo and bar."
-          scriptler:
-              script: print-path
-          reference: STR_PARAM
-          visible-item-count: 10
-          choice-type: input-text 
+          - active-choice-reactive-reference:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_REF_06
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_06 with options foo and bar."
+              scriptler:
+                  script: print-path
+                  parameters:
+                      - PARAM1: value1
+              reference: STR_PARAM
+              visible-item-count: 10
+              choice-type: input-text 
+
+          - active-choice-reactive-reference:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_REF_07
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_07 with options foo and bar."
+              scriptler:
+                  script: print-path
+              reference: STR_PARAM,CHOICE_PARAM
+              visible-item-count: 10
+              choice-type: input-text 
+              filterable:  true
+              filter-length: 8
 

--- a/dev-files/dev.yml
+++ b/dev-files/dev.yml
@@ -1,0 +1,244 @@
+- job:
+    name: 'active-choice-example'
+
+    parameters:
+      - string:
+          name: STR_PARAM
+          default: test
+
+      - active-choice:
+          project: 'active-choice-example'
+          name: ACTIVE_CHOICE_01
+          description: "A parameter named ACTIVE_CHOICE_01 with options foo and bar."
+          groovy:
+              script: |
+                  return ['foo:selected', 'bar']
+              classpath: /tmp/aklsdjfkl.jar
+              sandbox: false
+          fallback:
+              script: |
+                  return ['Error']
+          visible-item-count: 1
+          choice-type: single
+          filterable:  true
+          filter-length: 1
+
+      - active-choice:
+          project: 'active-choice-example'
+          name: ACTIVE_CHOICE_02
+          description: "A parameter named ACTIVE_CHOICE_02 with options foo and bar."
+          groovy:
+              script: |
+                  return ['foo:selected', 'bar']
+          fallback:
+              script: |
+                  return ['Error']
+              sandbox: true
+              classpath: /tmp/aklsdjfkl.jar
+          visible-item-count: 1
+          choice-type: multi
+          filterable:  false
+
+      - active-choice:
+          project: 'active-choice-example'
+          name: ACTIVE_CHOICE_03
+          description: "A parameter named ACTIVE_CHOICE_03 with options foo and bar."
+          groovy:
+              script: |
+                  return ['foo:selected', 'bar']
+          fallback:
+              script: |
+                  return ['Error']
+              sandbox: true
+              classpath: /tmp/aklsdjfkl.jar
+          visible-item-count: 1
+          choice-type: radio
+
+      - active-choice:
+          project: 'active-choice-example'
+          name: ACTIVE_CHOICE_04
+          description: "A parameter named ACTIVE_CHOICE_04 with options foo and bar."
+          groovy:
+              script: |
+                  return ['foo:selected', 'bar']
+          fallback:
+              script: |
+                  return ['Error']
+              sandbox: true
+              classpath: /tmp/aklsdjfkl.jar
+          visible-item-count: 1
+          choice-type: checkbox
+
+      - active-choice:
+          project: 'active-choice-example'
+          name: ACTIVE_CHOICE_05
+          description: "A parameter named ACTIVE_CHOICE_05 with options foo and bar."
+          scriptler:
+              script: print-path
+              parameters:
+                  - PARAM1:  value1
+                  - PARAM2:  value2
+          visible-item-count: 1
+          choice-type: checkbox
+
+      - active-choice-reactive:
+          project: 'active-choice-example'
+          name: ACTIVE_CHOICE_REACTIVE_01
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_01 with options foo and bar."
+          groovy:
+              script: |
+                  return ['foo:selected', 'bar']
+              classpath: /tmp/aklsdjfkl.jar
+          fallback:
+              script: |
+                  return ['Error']
+              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              sandbox: true
+          visible-item-count: 10
+          reference: STR_PARAM
+          choice-type: multi
+
+      - active-choice-reactive:
+          project: 'active-choice-example'
+          name: ACTIVE_CHOICE_REACTIVE_02
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_02 with options foo and bar."
+          groovy:
+              script: |
+                  return ['foo:selected', 'bar']
+              classpath: /your-path/your-classes.jar
+              sandbox: true
+          reference: STR_PARAM,ACTIVE_CHOICE_01
+          visible-item-count: 10
+          choice-type: radio
+          filterable:  true
+          filter-length:  1
+
+      - active-choice-reactive:
+          project: 'active-choice-example'
+          name: ACTIVE_CHOICE_REACTIVE_03
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_03 with options foo and bar."
+          scriptler:
+              script: print-path
+              parameters:
+                  - PARAM1:  value1
+                  - PARAM2:  value2
+          reference: STR_PARAM
+          visible-item-count: 10
+          choice-type: checkbox
+
+      - active-choice-reactive:
+          project: 'active-choice-example'
+          name: ACTIVE_CHOICE_REACTIVE_04
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_04 with options foo and bar."
+          scriptler:
+              script: print-path
+          reference: STR_PARAM
+          visible-item-count: 10
+          choice-type: checkbox
+
+      - active-choice-reactive-reference:
+          name: ACTIVE_CHOICE_REACTIVE_REF_01
+          project: 'active-choice-example'
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_01 with options foo and bar."
+          groovy:
+              script: |
+                  return ['foo:selected', 'bar']
+              classpath: /tmp/aklsdjfkl.jar
+              sandbox: true
+          fallback:
+              script: |
+                  return ['Error']
+              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+          reference: STR_PARAM
+          omit-value: false
+          choice-type: input-text
+
+      - active-choice-reactive-reference:
+          name: ACTIVE_CHOICE_REACTIVE_REF_02
+          project: 'active-choice-example'
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_02 with options foo and bar."
+          groovy:
+              script: |
+                  return ['foo:selected', 'bar']
+              classpath: /tmp/aklsdjfkl.jar
+              sandbox: true
+          fallback:
+              script: |
+                  return ['Error']
+              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+          reference: STR_PARAM,ACTIVE_CHOICE_01
+          omit-value: false
+          choice-type: numbered-list
+
+      - active-choice-reactive-reference:
+          name: ACTIVE_CHOICE_REACTIVE_REF_03
+          project: 'active-choice-example'
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_03 with options foo and bar."
+          groovy:
+              script: |
+                  return ['foo:selected', 'bar']
+              classpath: /tmp/aklsdjfkl.jar
+              sandbox: true
+          fallback:
+              script: |
+                  return ['Error']
+              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+          reference: STR_PARAM
+          omit-value: false
+          choice-type: bullet-list
+
+      - active-choice-reactive-reference:
+          name: ACTIVE_CHOICE_REACTIVE_REF_04
+          project: 'active-choice-example'
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_04 with options foo and bar."
+          groovy:
+              script: |
+                  return ['foo:selected', 'bar']
+              classpath: /tmp/aklsdjfkl.jar
+              sandbox: true
+          fallback:
+              script: |
+                  return ['Error']
+              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+          reference: STR_PARAM
+          omit-value: false
+          choice-type: formatted-html
+
+      - active-choice-reactive-reference:
+          name: ACTIVE_CHOICE_REACTIVE_REF_05
+          project: 'active-choice-example'
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_05 with options foo and bar."
+          groovy:
+              script: |
+                  return ['foo:selected', 'bar']
+              sandbox: true
+          fallback:
+              script: |
+                  return ['Error']
+              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+          reference: STR_PARAM
+          omit-value: false
+          choice-type: formatted-hidden-html
+
+      - active-choice-reactive-reference:
+          project: 'active-choice-example'
+          name: ACTIVE_CHOICE_REACTIVE_REF_06
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_06 with options foo and bar."
+          scriptler:
+              script: print-path
+              parameters:
+                - PARAM1: value1
+          reference: STR_PARAM
+          visible-item-count: 10
+          choice-type: input-text 
+
+      - active-choice-reactive-reference:
+          project: 'active-choice-example'
+          name: ACTIVE_CHOICE_REACTIVE_REF_07
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_07 with options foo and bar."
+          scriptler:
+              script: print-path
+          reference: STR_PARAM
+          visible-item-count: 10
+          choice-type: input-text 
+

--- a/dev-files/dev.yml
+++ b/dev-files/dev.yml
@@ -13,8 +13,8 @@
           groovy:
               script: |
                   return ['foo:selected', 'bar']
-              classpath: /tmp/aklsdjfkl.jar
-              sandbox: false
+              classpath: file:/tmp/aklsdjfkl.jar
+              sandbox: false        
           fallback:
               script: |
                   return ['Error']
@@ -33,8 +33,8 @@
           fallback:
               script: |
                   return ['Error']
-              sandbox: true
-              classpath: /tmp/aklsdjfkl.jar
+              sandbox: true    
+              classpath: file:/tmp/aklsdjfkl.jar
           visible-item-count: 1
           choice-type: multi
           filterable:  false
@@ -49,8 +49,8 @@
           fallback:
               script: |
                   return ['Error']
-              sandbox: true
-              classpath: /tmp/aklsdjfkl.jar
+              sandbox: true    
+              classpath: file:/tmp/aklsdjfkl.jar
           visible-item-count: 1
           choice-type: radio
 
@@ -64,8 +64,8 @@
           fallback:
               script: |
                   return ['Error']
-              sandbox: true
-              classpath: /tmp/aklsdjfkl.jar
+              sandbox: true    
+              classpath: file:/tmp/aklsdjfkl.jar
           visible-item-count: 1
           choice-type: checkbox
 
@@ -76,7 +76,7 @@
           scriptler:
               script: print-path
               parameters:
-                  - PARAM1:  value1
+                  - PARAM1:  value1 alksdjflksdf lkasjflk
                   - PARAM2:  value2
           visible-item-count: 1
           choice-type: checkbox
@@ -88,12 +88,12 @@
           groovy:
               script: |
                   return ['foo:selected', 'bar']
-              classpath: /tmp/aklsdjfkl.jar
+              classpath: file:/tmp/aklsdjfkl.jar
           fallback:
               script: |
                   return ['Error']
-              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
-              sandbox: true
+              classpath: file:/tmp/aklsdjfkl.jar,https://lakjsdfklsdjklf/lkajsdflk.jar
+              sandbox: true    
           visible-item-count: 10
           reference: STR_PARAM
           choice-type: multi
@@ -105,8 +105,8 @@
           groovy:
               script: |
                   return ['foo:selected', 'bar']
-              classpath: /your-path/your-classes.jar
-              sandbox: true
+              classpath: file:/your-path/your-classes.jar
+              sandbox: true    
           reference: STR_PARAM,ACTIVE_CHOICE_01
           visible-item-count: 10
           choice-type: radio
@@ -120,7 +120,7 @@
           scriptler:
               script: print-path
               parameters:
-                  - PARAM1:  value1
+                  - PARAM1:  value1 aklfsdj kalsjflk
                   - PARAM2:  value2
           reference: STR_PARAM
           visible-item-count: 10
@@ -143,12 +143,12 @@
           groovy:
               script: |
                   return ['foo:selected', 'bar']
-              classpath: /tmp/aklsdjfkl.jar
-              sandbox: true
+              classpath: file:/tmp/aklsdjfkl.jar
+              sandbox: true    
           fallback:
               script: |
                   return ['Error']
-              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
           reference: STR_PARAM
           omit-value: false
           choice-type: input-text
@@ -160,12 +160,12 @@
           groovy:
               script: |
                   return ['foo:selected', 'bar']
-              classpath: /tmp/aklsdjfkl.jar
-              sandbox: true
+              classpath: file:/tmp/aklsdjfkl.jar
+              sandbox: true    
           fallback:
               script: |
                   return ['Error']
-              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
           reference: STR_PARAM,ACTIVE_CHOICE_01
           omit-value: false
           choice-type: numbered-list
@@ -177,12 +177,12 @@
           groovy:
               script: |
                   return ['foo:selected', 'bar']
-              classpath: /tmp/aklsdjfkl.jar
-              sandbox: true
+              classpath: file:/tmp/aklsdjfkl.jar
+              sandbox: true    
           fallback:
               script: |
                   return ['Error']
-              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
           reference: STR_PARAM
           omit-value: false
           choice-type: bullet-list
@@ -194,12 +194,12 @@
           groovy:
               script: |
                   return ['foo:selected', 'bar']
-              classpath: /tmp/aklsdjfkl.jar
-              sandbox: true
+              classpath: file:/tmp/aklsdjfkl.jar
+              sandbox: true    
           fallback:
               script: |
                   return ['Error']
-              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
           reference: STR_PARAM
           omit-value: false
           choice-type: formatted-html
@@ -211,11 +211,11 @@
           groovy:
               script: |
                   return ['foo:selected', 'bar']
-              sandbox: true
+              sandbox: true    
           fallback:
               script: |
                   return ['Error']
-              classpath: /tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
           reference: STR_PARAM
           omit-value: false
           choice-type: formatted-hidden-html
@@ -227,7 +227,7 @@
           scriptler:
               script: print-path
               parameters:
-                - PARAM1: value1
+                  - PARAM1: value1
           reference: STR_PARAM
           visible-item-count: 10
           choice-type: input-text 

--- a/dev-files/ref-config.xml
+++ b/dev-files/ref-config.xml
@@ -1,0 +1,171 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.29">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STRING_REFERENCE</name>
+          <description>enter a string</description>
+          <defaultValue>string-value</defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_01</name>
+          <description>make a decision</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice1</string>
+              <string>choice2</string>
+              <string>choice3</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.ChoiceParameter plugin="uno-choice@2.1">
+          <name>ACTIVE_CHOICE_01</name>
+          <description>asdfsdfj lkajsfdlk</description>
+          <randomName>choice-parameter-8211497161494630</randomName>
+          <visibleItemCount>1</visibleItemCount>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript plugin="script-security@1.48">
+              <script>return [
+&apos;choice1&apos;,
+&apos;choice2&apos;
+]</script>
+              <sandbox>false</sandbox>
+            </secureScript>
+            <secureFallbackScript plugin="script-security@1.48">
+              <script>return [&apos;error&apos;]</script>
+              <sandbox>false</sandbox>
+            </secureFallbackScript>
+          </script>
+          <projectName>_WIP_allen_dev</projectName>
+          <choiceType>PT_SINGLE_SELECT</choiceType>
+          <filterable>true</filterable>
+          <filterLength>1</filterLength>
+        </org.biouno.unochoice.ChoiceParameter>
+        <org.biouno.unochoice.ChoiceParameter plugin="uno-choice@2.1">
+          <name>ACTIVE_CHOICE_02</name>
+          <description>asfsdfsdfds</description>
+          <randomName>choice-parameter-8211497163550320</randomName>
+          <visibleItemCount>1</visibleItemCount>
+          <script class="org.biouno.unochoice.model.ScriptlerScript">
+            <parameters class="linked-hash-map"/>
+          </script>
+          <projectName>_WIP_allen_dev</projectName>
+          <choiceType>PT_RADIO</choiceType>
+          <filterable>true</filterable>
+          <filterLength>1</filterLength>
+        </org.biouno.unochoice.ChoiceParameter>
+        <org.biouno.unochoice.CascadeChoiceParameter plugin="uno-choice@2.1">
+          <name>ACTIVE_CHOICE_REACTIVE_01</name>
+          <description>asfdsfsdfsdfsd</description>
+          <randomName>choice-parameter-8211497165584010</randomName>
+          <visibleItemCount>1</visibleItemCount>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript plugin="script-security@1.48">
+              <script>return [
+&apos;choice1&apos;,
+&apos;choice2&apos;
+]</script>
+              <sandbox>false</sandbox>
+            </secureScript>
+            <secureFallbackScript plugin="script-security@1.48">
+              <script>return [&apos;error&apos;]</script>
+              <sandbox>false</sandbox>
+            </secureFallbackScript>
+          </script>
+          <projectName>_WIP_allen_dev</projectName>
+          <parameters class="linked-hash-map"/>
+          <referencedParameters>STRING_REFERENCE,CHOICE_01</referencedParameters>
+          <choiceType>PT_MULTI_SELECT</choiceType>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+        </org.biouno.unochoice.CascadeChoiceParameter>
+        <org.biouno.unochoice.DynamicReferenceParameter plugin="uno-choice@2.1">
+          <name>ACTIVE_CHOICES_REACTIVE_REF</name>
+          <description></description>
+          <randomName>choice-parameter-8211497167634601</randomName>
+          <visibleItemCount>1</visibleItemCount>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript plugin="script-security@1.48">
+              <script>return [
+&apos;choice1&apos;,
+&apos;choice2&apos;
+]</script>
+              <sandbox>false</sandbox>
+            </secureScript>
+            <secureFallbackScript plugin="script-security@1.48">
+              <script>return [&apos;error&apos;]</script>
+              <sandbox>false</sandbox>
+            </secureFallbackScript>
+          </script>
+          <projectName>_WIP_allen_dev</projectName>
+          <parameters class="linked-hash-map"/>
+          <referencedParameters>STRING_REFERENCE,CHOICE_01</referencedParameters>
+          <choiceType>ET_ORDERED_LIST</choiceType>
+          <omitValueField>true</omitValueField>
+        </org.biouno.unochoice.DynamicReferenceParameter>
+        <org.biouno.unochoice.CascadeChoiceParameter plugin="uno-choice@2.1">
+          <name>SCRIPTLER_01</name>
+          <description>testing scriptler with parameters</description>
+          <randomName>choice-parameter-8217693238970276</randomName>
+          <visibleItemCount>1</visibleItemCount>
+          <script class="org.biouno.unochoice.model.ScriptlerScript">
+            <scriptlerScriptId>print-path.groovy</scriptlerScriptId>
+            <parameters class="linked-hash-map">
+              <entry>
+                <string>HELPME</string>
+                <string>lkajklsf</string>
+              </entry>
+              <entry>
+                <string>P2</string>
+                <string>aklsfdjlksd</string>
+              </entry>
+            </parameters>
+          </script>
+          <projectName>_WIP_allen_dev</projectName>
+          <parameters class="linked-hash-map"/>
+          <referencedParameters></referencedParameters>
+          <choiceType>PT_SINGLE_SELECT</choiceType>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+        </org.biouno.unochoice.CascadeChoiceParameter>
+        <org.biouno.unochoice.CascadeChoiceParameter plugin="uno-choice@2.1">
+          <name>SCRIPTLER_02</name>
+          <description>testing scriptler no parameters</description>
+          <randomName>choice-parameter-8217820280760511</randomName>
+          <visibleItemCount>1</visibleItemCount>
+          <script class="org.biouno.unochoice.model.ScriptlerScript">
+            <scriptlerScriptId>print-path.groovy</scriptlerScriptId>
+            <parameters class="linked-hash-map"/>
+          </script>
+          <projectName>_WIP_allen_dev</projectName>
+          <parameters class="linked-hash-map"/>
+          <referencedParameters></referencedParameters>
+          <choiceType>PT_SINGLE_SELECT</choiceType>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+        </org.biouno.unochoice.CascadeChoiceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <jdk>(System)</jdk>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>
+

--- a/jenkins_jobs_active_choice/active_choice.py
+++ b/jenkins_jobs_active_choice/active_choice.py
@@ -21,14 +21,14 @@ import re
 # XXXXXX still here for backwards compatibility
 # these are common tags for both cascade-choice and dynamic-reference
 SCRIPT_OPTIONAL = [
-    # ( yaml tag, xml tag, default value )
+    # fields( yaml tag, xml tag, default value )
     ('script-sandbox', 'sandbox', 'False'),
     ('script-classpath', 'classpath', 'False'),
 ]
 
 # XXXXXX still here for backwards compatibility
 FALLBACK_OPTIONAL = [
-    #( yaml tag, xml tag, default value )
+    # fields( yaml tag, xml tag, default value )
     ('fallback-sandbox', 'sandbox', 'False'),
     ('fallback-classpath', 'classpath', 'False'),
 ]
@@ -68,7 +68,7 @@ def _add_classpath(xml_parent, data):
         # create the classpath section
         section = Xml.SubElement(xml_parent, 'classpath')
         # add the elements
-        uri_match = re.compile (r"(file:/|https*://)", re.IGNORECASE)
+        uri_match = re.compile(r"(file:/|https*://)", re.IGNORECASE)
         for url in [x.strip() for x in data.split(',')]:
             if uri_match.match(url):
                 _add_element(section, 'entry', url)
@@ -120,7 +120,6 @@ def _add_scriptler(xml_parent, param_name, data):
         raise Exception("missing Scriptler script argument in %s" % param_name)
 
 
-
 def _unique_string(project, name):
     return 'choice-param-{0}-{1}'.format(project, name).lower()
 
@@ -158,13 +157,13 @@ def cascade_choice_parameter(parser, xml_parent, data):
     }
 
     REQUIRED = [
-        # (yaml tag)
+        # fields(yaml tag)
         ('name', 'name'),
         ('project', 'projectName'),
     ]
 
     OPTIONAL = [
-        # ( yaml tag, xml tag, default value )
+        # fields( yaml tag, xml tag, default value )
         ('description', 'description', ''),
         ('visible-item-count', 'visibleItemCount', 1),
         ('reference', 'referencedParameters', ''),
@@ -235,13 +234,13 @@ def dynamic_reference_parameter(parser, xml_parent, data):
     }
 
     REQUIRED = [
-        # (yaml tag)
+        # fields(yaml tag)
         ('name', 'name'),
         ('project', 'projectName')
     ]
 
     OPTIONAL = [
-        # ( yaml tag, xml tag, default value )
+        # fields( yaml tag, xml tag, default value )
         ('description', 'description', ''),
         ('reference', 'referencedParameters', ''),
         ('omit-value', 'omitValueField', False)
@@ -302,7 +301,7 @@ def common_steps(xml_parent, element_name, REQUIRED, OPTIONAL, CHOICE_TYPE, data
     # if both groovy/fallback and scriptler, raise an error
     if (groovy or fallback) and scriptler:
         raise Exception("illegal use of both groovy/fallback and scriptler scripts in the same parameter %s"
-                % param_name)
+                        % param_name)
 
     # at this point, we know it's either groovy/fallback or scriptler, but not both
     if groovy:
@@ -396,13 +395,13 @@ def active_choice(parser, xml_parent, data):
     }
 
     REQUIRED = [
-        # (yaml tag)
+        # fields(yaml tag)
         ('name', 'name'),
         ('project', 'projectName'),
     ]
 
     OPTIONAL = [
-        # ( yaml tag, xml tag, default value )
+        # fields( yaml tag, xml tag, default value )
         ('description', 'description', ''),
         ('visible-item-count', 'visibleItemCount', 1),
         ('filterable', 'filterable', False),
@@ -411,6 +410,7 @@ def active_choice(parser, xml_parent, data):
 
     element_name = 'org.biouno.unochoice.ChoiceParameter'
     common_steps(xml_parent, element_name, REQUIRED, OPTIONAL, CHOICE_TYPE, data)
+
 
 def active_choice_reactive(parser, xml_parent, data):
     """yaml: active-choice-reactive
@@ -489,13 +489,13 @@ def active_choice_reactive(parser, xml_parent, data):
     }
 
     REQUIRED = [
-        # (yaml tag)
+        # fields(yaml tag)
         ('name', 'name'),
         ('project', 'projectName'),
     ]
 
     OPTIONAL = [
-        # ( yaml tag, xml tag, default value )
+        # fields( yaml tag, xml tag, default value )
         ('description', 'description', ''),
         ('visible-item-count', 'visibleItemCount', 1),
         ('reference', 'referencedParameters', ''),
@@ -585,13 +585,13 @@ def active_choice_reactive_reference(parser, xml_parent, data):
     }
 
     REQUIRED = [
-        # (yaml tag)
+        # fields(yaml tag)
         ('name', 'name'),
         ('project', 'projectName'),
     ]
 
     OPTIONAL = [
-        # ( yaml tag, xml tag, default value )
+        # fields( yaml tag, xml tag, default value )
         ('description', 'description', ''),
         ('visible-item-count', 'visibleItemCount', 1),
         ('reference', 'referencedParameters', ''),

--- a/jenkins_jobs_active_choice/active_choice.py
+++ b/jenkins_jobs_active_choice/active_choice.py
@@ -18,6 +18,7 @@ import xml.etree.ElementTree as Xml
 import re
 
 
+# XXXXXX still here for backwards compatibility
 # these are common tags for both cascade-choice and dynamic-reference
 SCRIPT_OPTIONAL = [
     # ( yaml tag, xml tag, default value )
@@ -25,6 +26,7 @@ SCRIPT_OPTIONAL = [
     ('script-classpath', 'classpath', 'False'),
 ]
 
+# XXXXXX still here for backwards compatibility
 FALLBACK_OPTIONAL = [
     # ( yaml tag, xml tag, default value )
     ('fallback-sandbox', 'sandbox', 'False'),
@@ -96,9 +98,9 @@ def _add_groovy(xml_parent, param_name, groovy_data, fallback_data):
 
 
 def _add_scriptler_parameters(xml_parent, data):
+    # create the parameters section
+    parameters = Xml.SubElement(xml_parent, 'parameters', {'class': 'linked-hash-map'})
     if data:
-        # create the parameters section
-        parameters = Xml.SubElement(xml_parent, 'parameters', {'class': 'linked-hash-map'})
         # add the parameters
         for d in data:
             for k, v in d.items():
@@ -299,16 +301,19 @@ def common_steps(xml_parent, element_name, REQUIRED, OPTIONAL, CHOICE_TYPE, data
         raise Exception("illegal use of both groovy/fallback and scriptler scripts in the same parameter %s" % param_name)
 
     # at this point, we know it's either groovy/fallback or scriptler, but not both
-
     if groovy:
         # add groovy, along with optional fallback
-        _add_groovy(section, param_name, data.get('groovy'), data.get('fallback'))
+        _add_groovy(section, param_name, groovy, fallback)
     elif scriptler:
         # add scriptler
-        _add_scriptler(section, param_name, data.get('scriptler'))
+        _add_scriptler(section, param_name, scriptler)
 
-    # set the choice-type; default is single
+    # set the choice-type
     _add_element(section, 'choiceType', CHOICE_TYPE[data.get('choice-type', 'default')])
+
+    # add an empty parameters section
+    # not sure why this is needed, but this is what the active choice plug-in does, so...
+    Xml.SubElement(section, 'parameters', {'class': 'linked-hash-map'})
 
     # add calculated fields
     _add_element(section, 'randomName', _unique_string(data['project'], param_name))

--- a/jenkins_jobs_active_choice/active_choice.py
+++ b/jenkins_jobs_active_choice/active_choice.py
@@ -123,6 +123,7 @@ def _unique_string(project, name):
     return 'choice-param-{0}-{1}'.format(project, name).lower()
 
 
+# XXXXXXX still here for backwards compatibility
 def cascade_choice_parameter(parser, xml_parent, data):
     """yaml: cascade-choice
     Creates an active choice parameter
@@ -191,11 +192,12 @@ def cascade_choice_parameter(parser, xml_parent, data):
     _add_script(scripts, "secureFallbackScript", data.get("fallback-script", ""))
 
     _add_element(section, 'choiceType', CHOICE_TYPE[data.get('choice-type', 'single')])
-    # added calculated fields
+    # add calculated fields
     logging.debug('cascade_choice data: %s' % data['project'])
     _add_element(section, 'randomName', _unique_string(data['project'], data['name']))
     
 
+# XXXXXXX still here for backwards compatibility
 def dynamic_reference_parameter(parser, xml_parent, data):
     """yaml: dynamic-reference
     Creates an active choice dynamic reference parameter
@@ -263,7 +265,7 @@ def dynamic_reference_parameter(parser, xml_parent, data):
     _add_script(scripts, "secureFallbackScript", data.get("fallback-script", ""))
 
     _add_element(section, 'choiceType', CHOICE_TYPE[data.get('choice-type', 'input-text')])
-    # added calculated fields
+    # add calculated fields
     _add_element(section, 'randomName', _unique_string(data['project'], data['name']))
     
 
@@ -306,9 +308,9 @@ def common_steps(xml_parent, element_name, REQUIRED, OPTIONAL, CHOICE_TYPE, data
         _add_scriptler(section, param_name, data.get('scriptler'))
 
     # set the choice-type; default is single
-    _add_element(section, 'choiceType', CHOICE_TYPE[data.get('choice-type', 'single')])
+    _add_element(section, 'choiceType', CHOICE_TYPE[data.get('choice-type', 'default')])
 
-    # added calculated fields
+    # add calculated fields
     _add_element(section, 'randomName', _unique_string(data['project'], param_name))
 
 
@@ -318,26 +320,27 @@ def active_choice(parser, xml_parent, data):
     Creates an active choice parameter
     Requires the Jenkins :jenkins-wiki:`Active Choices Plugin <Active+Choices+Plugin>`.
 
-    :arg str name: the name of the parameter
-    :arg str project: the project name (can be anything; not really used)
-    :arg str description: a description of the parameter (optional)
-    # USE EITHER groovy or scripter, not both
+    :arg str name: the name of the parameter (REQUIRED)
+    :arg str project: the project name (not really used for anything so any value will do) (REQUIRED)
+    :arg str description: a description of the parameter (OPTIONAL)
+    # REQUIRED: YOU MUST USE EITHER groovy or scripter, not both
     :arg hash-map groovy: the section to define the main groovy script to generate the values for this parameter
         :arg str script: the actual groovy script
-        :arg str classpath: additional class paths for your groovy code (optional; absolutes paths or URLs)
-        :arg str sandbox: run this script in a sandbox (optional; default false)
-    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main groovy fails (optional)
-        :arg str script: the actual fallback groovy script
-        :arg str classpath: additional class paths for your groovy code (optional)
-        :arg str sandbox: run this script in a sandbox (optional; default false)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
+    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main groovy fails (OPTIONAL)
+        :arg str script: the actual fallback groovy script (REQIRED, IF you define fallback)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
     :arg hash-map scriptler: the section to define the main groovy script to generate the values for this parameter
-        :arg str script: simple file name of the scriptler script from the system library of scripts; not an absolute path
-        :arg hash-map parameters: list of parameters (optional; key-value pairs)
+        :arg str script: simple file name of the scriptler script from the system library of scripts; not an 
+            absolute path (REQIRED, IF you define scriptler)
+        :arg list parameters: list of parameters (OPTIONAL; key-value pairs)
             :arg key-value "<KEYNAME>: <VALUE>" 
             ...
-    arg: str choice-type: a choice type, can be on of single, multi, radio, checkbox
-    arg: bool filterable: provide interactive filtering (optional; default false)
-    arg: bool filter-length: number of lines to show in the filter (optional; default 1)
+    arg: str choice-type: a choice type, can be on of single, multi, radio, checkbox (OPTIONAL; default single)
+    arg: bool filterable: provide interactive filtering (OPTIONAL; default false)
+    arg: bool filter-length: number of lines to show in the filter (OPTIONAL; default 1)
     Example::
 
     .. code-block:: yaml
@@ -364,16 +367,17 @@ def active_choice(parser, xml_parent, data):
           project: 'active-choice-example'
           description: "A parameter named ACTIVE_CHOICE_01 with options foo and bar."
           scriptler:
-              script: my-scriptler-script
+              script: foo-bar-scriptler
               parameters:
-                  PARAM1:  some-value01
-                  PARAM2:  some-value02
+                  - PARAM1:  some-value01
+                  - PARAM2:  some-value02
           visible-item-count: 1
           choice-type: single
 
     """
 
     CHOICE_TYPE = {
+        'default': 'PT_SINGLE_SELECT',
         'single': 'PT_SINGLE_SELECT',
         'multi': 'PT_MULTI_SELECT',
         'checkbox': 'PT_CHECKBOX',
@@ -402,36 +406,37 @@ def active_choice_reactive(parser, xml_parent, data):
     Creates an active choice reactive parameter
     Requires the Jenkins :jenkins-wiki:`Active Choices Plugin <Active+Choices+Plugin>`.
 
-    :arg str name: the name of the parameter
-    :arg str project: the project name (can be anything; not really used)
-    :arg str description: a description of the parameter (optional)
-    # USE EITHER groovy or scripter, not both
+    :arg str name: the name of the parameter (REQUIRED)
+    :arg str project: the project name (not really used for anything so any value will do) (REQUIRED)
+    :arg str description: a description of the parameter (OPTIONAL)
+    # REQUIRED: YOU MUST USE EITHER groovy or scripter, not both
     :arg hash-map groovy: the section to define the main groovy script to generate the values for this parameter
         :arg str script: the actual groovy script
-        :arg str classpath: additional class paths for your groovy code (optional; absolutes paths or URLs)
-        :arg str sandbox: run this script in a sandbox (optional; default false)
-    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main groovy fails (optional)
-        :arg str script: the actual fallback groovy script
-        :arg str classpath: additional class paths for your groovy code (optional)
-        :arg str sandbox: run this script in a sandbox (optional; default false)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
+    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main groovy fails (OPTIONAL)
+        :arg str script: the actual fallback groovy script (REQIRED, IF you define fallback)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
     :arg hash-map scriptler: the section to define the main groovy script to generate the values for this parameter
-        :arg str script: simple file name of the scriptler script from the system library of scripts; not an absolute path
-        :arg hash-map parameters: list of parameters (optional; key-value pairs)
+        :arg str script: simple file name of the scriptler script from the system library of scripts; not an 
+            absolute path (REQIRED, IF you define scriptler)
+        :arg list parameters: list of parameters (OPTIONAL; key-value pairs)
             :arg key-value "<KEYNAME>: <VALUE>" 
             ...
-    arg: str choice-type: a choice type, can be on of single, multi, radio, checkbox
-    arg: str reference: comma-separated list of other PARAMETERS to which this one will react
-    arg: bool filterable: provide interactive filtering (optional; default false)
-    arg: bool filter-length: number of lines to show in the filter (optional; default 1)
+    arg: str choice-type: a choice type, can be on of single, multi, radio, checkbox (OPTIONAL; default single)
+    arg: bool filterable: provide interactive filtering (OPTIONAL; default false)
+    arg: bool filter-length: number of lines to show in the filter (OPTIONAL; default 1)
+    arg: str reference: comma-separated list of other PARAMETERS to which this one will react (OPTIONAL; but if you leave it out, what's the point?)
     Example::
 
     .. code-block:: yaml
 
     # using groovy
-    - active-choice:
-          name: ACTIVE_CHOICE_01
-          project: 'active-choice-example'
-          description: "A parameter named ACTIVE_CHOICE_01 with options foo and bar."
+    - active-choice-reactive:
+          name: ACTIVE_CHOICE_REACTIVE_01
+          project: 'active-choice-reactive-example'
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_01 with options foo and bar."
           groovy:
               script: |
                   return ['foo:selected', 'bar']
@@ -445,15 +450,15 @@ def active_choice_reactive(parser, xml_parent, data):
           choice-type: single
 
     # using scriptler
-    - active-choice:
-          name: ACTIVE_CHOICE_01
-          project: 'active-choice-example'
-          description: "A parameter named ACTIVE_CHOICE_01 with options foo and bar."
+    - active-choice-reactive:
+          name: ACTIVE_CHOICE_REACTIVE_02
+          project: 'active-choice-reactive-example'
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_02 with options foo and bar."
           scriptler:
-              script: my-scriptler-script
+              script: foo-bar-scriptler
               parameters:
-                  PARAM1:  some-value01
-                  PARAM2:  some-value02
+                  - PARAM1:  some-value01
+                  - PARAM2:  some-value02
           visible-item-count: 1
           reference: STR_PARAM,CHOICE_PARAM
           choice-type: single
@@ -461,6 +466,7 @@ def active_choice_reactive(parser, xml_parent, data):
     """
 
     CHOICE_TYPE = {
+        'default': 'PT_SINGLE_SELECT',
         'single': 'PT_SINGLE_SELECT',
         'multi': 'PT_MULTI_SELECT',
         'checkbox': 'PT_CHECKBOX',
@@ -491,36 +497,38 @@ def active_choice_reactive_reference(parser, xml_parent, data):
     Creates an active choice reactive reference parameter
     Requires the Jenkins :jenkins-wiki:`Active Choices Plugin <Active+Choices+Plugin>`.
 
-    :arg str name: the name of the parameter
-    :arg str project: the project name (can be anything; not really used)
-    :arg str description: a description of the parameter (optional)
-    # USE EITHER groovy or scripter, not both
+    :arg str name: the name of the parameter (REQUIRED)
+    :arg str project: the project name (not really used for anything so any value will do) (REQUIRED)
+    :arg str description: a description of the parameter (OPTIONAL)
+    # REQUIRED: YOU MUST USE EITHER groovy or scripter, not both
     :arg hash-map groovy: the section to define the main groovy script to generate the values for this parameter
         :arg str script: the actual groovy script
-        :arg str classpath: additional class paths for your groovy code (optional; absolutes paths or URLs)
-        :arg str sandbox: run this script in a sandbox (optional; default false)
-    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main groovy fails (optional)
-        :arg str script: the actual fallback groovy script
-        :arg str classpath: additional class paths for your groovy code (optional)
-        :arg str sandbox: run this script in a sandbox (optional; default false)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
+    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main groovy fails (OPTIONAL)
+        :arg str script: the actual fallback groovy script (REQIRED, IF you define fallback)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
     :arg hash-map scriptler: the section to define the main groovy script to generate the values for this parameter
-        :arg str script: simple file name of the scriptler script from the system library of scripts; not an absolute path
-        :arg hash-map parameters: list of parameters (optional; key-value pairs)
+        :arg str script: simple file name of the scriptler script from the system library of scripts; not an 
+            absolute path (REQIRED, IF you define scriptler)
+        :arg list parameters: list of parameters (OPTIONAL; key-value pairs)
             :arg key-value "<KEYNAME>: <VALUE>" 
             ...
-    arg: str choice-type: a choice type, can be on of input-text, numbered-list, bullet-list, formatted-html, formatted-hidden-html
-    arg: str reference: comma-separated list of other PARAMETERS to which this one will react
-    arg: bool filterable: provide interactive filtering (optional; default false)
-    arg: bool filter-length: number of lines to show in the filter (optional; default 1)
+    arg: str choice-type: a choice type, can be on of single, multi, radio, checkbox (OPTIONAL; default single)
+    arg: bool filterable: provide interactive filtering (OPTIONAL; default false)
+    arg: bool filter-length: number of lines to show in the filter (OPTIONAL; default 1)
+    arg: str reference: comma-separated list of other PARAMETERS to which this one will react (OPTIONAL; but if you 
+        leave it out, what's the point?)
     Example::
 
     .. code-block:: yaml
 
     # using groovy
     - active-choice-reactive-reference:
-          name: ACTIVE_CHOICE_01
-          project: 'active-choice-example'
-          description: "A parameter named ACTIVE_CHOICE_01 with options foo and bar."
+          name: ACTIVE_CHOICE_REACTIVE_REFERENCE_01
+          project: 'active-choice-reactive-reference-example'
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REFERENCE_01 with options foo and bar."
           groovy:
               script: |
                   return ['foo:selected', 'bar']
@@ -535,14 +543,14 @@ def active_choice_reactive_reference(parser, xml_parent, data):
 
     # using scriptler
     - active-choice-reactive-reference:
-          name: ACTIVE_CHOICE_01
-          project: 'active-choice-example'
-          description: "A parameter named ACTIVE_CHOICE_01 with options foo and bar."
+          name: ACTIVE_CHOICE_REACTIVE_REFERENCE_02
+          project: 'active-choice-reactive-reference-example'
+          description: "A parameter named ACTIVE_CHOICE_REACTIVE_REFERENCE_02 with options foo and bar."
           scriptler:
-              script: my-scriptler-script
+              script: foo-bar-scriptler
               parameters:
-                  PARAM1:  some-value01
-                  PARAM2:  some-value02
+                  - PARAM1:  some-value01
+                  - PARAM2:  some-value02
           visible-item-count: 1
           reference: STR_PARAM,CHOICE_PARAM
           choice-type: input-text
@@ -550,6 +558,7 @@ def active_choice_reactive_reference(parser, xml_parent, data):
     """
 
     CHOICE_TYPE = {
+        'default': 'ET_TEXT_BOX',
         'input-text': 'ET_TEXT_BOX',
         'numbered-list': 'ET_ORDERED_LIST',
         'bullet-list': 'ET_UNORDERED_LIST',
@@ -574,5 +583,3 @@ def active_choice_reactive_reference(parser, xml_parent, data):
 
     element_name = 'org.biouno.unochoice.DynamicReferenceParameter'
     common_steps(xml_parent, element_name, REQUIRED, OPTIONAL, CHOICE_TYPE, data)
-
-

--- a/jenkins_jobs_active_choice/active_choice.py
+++ b/jenkins_jobs_active_choice/active_choice.py
@@ -28,7 +28,7 @@ SCRIPT_OPTIONAL = [
 
 # XXXXXX still here for backwards compatibility
 FALLBACK_OPTIONAL = [
-    # ( yaml tag, xml tag, default value )
+    #( yaml tag, xml tag, default value )
     ('fallback-sandbox', 'sandbox', 'False'),
     ('fallback-classpath', 'classpath', 'False'),
 ]
@@ -197,7 +197,7 @@ def cascade_choice_parameter(parser, xml_parent, data):
     # add calculated fields
     logging.debug('cascade_choice data: %s' % data['project'])
     _add_element(section, 'randomName', _unique_string(data['project'], data['name']))
-    
+
 
 # XXXXXXX still here for backwards compatibility
 def dynamic_reference_parameter(parser, xml_parent, data):
@@ -210,8 +210,11 @@ def dynamic_reference_parameter(parser, xml_parent, data):
     arg: str fallback-script: a groovy script which will be evaluated if main script fails (optional)
     :arg str description: a description of the parameter (optional)
     arg: str reference: the name(s) of parameter(s) on changing that the parameter will be re-evaluated
-    arg: str choice-type: a choice type, can be on of input-text, numbered-list, bullet-list, formatted-html, formatted-hidden-html
-    arg: bool omit-value: By default Dynamic Reference Parameters always include a hidden input for the value. If your script creates an input HTML element, you can check this option and the value input field will be omitted.
+    arg: str choice-type: a choice type, can be on of input-text, numbered-list, bullet-list, formatted-html,
+        formatted-hidden-html
+    arg: bool omit-value: By default Dynamic Reference Parameters always include a hidden input for the value.
+        If your script creates an input HTML element, you can check this option and the value input field will
+        be omitted.
     Example::
 
     .. code-block:: yaml
@@ -269,7 +272,7 @@ def dynamic_reference_parameter(parser, xml_parent, data):
     _add_element(section, 'choiceType', CHOICE_TYPE[data.get('choice-type', 'input-text')])
     # add calculated fields
     _add_element(section, 'randomName', _unique_string(data['project'], data['name']))
-    
+
 
 def common_steps(xml_parent, element_name, REQUIRED, OPTIONAL, CHOICE_TYPE, data):
     param_name = data.get('name')
@@ -298,7 +301,8 @@ def common_steps(xml_parent, element_name, REQUIRED, OPTIONAL, CHOICE_TYPE, data
 
     # if both groovy/fallback and scriptler, raise an error
     if (groovy or fallback) and scriptler:
-        raise Exception("illegal use of both groovy/fallback and scriptler scripts in the same parameter %s" % param_name)
+        raise Exception("illegal use of both groovy/fallback and scriptler scripts in the same parameter %s"
+                % param_name)
 
     # at this point, we know it's either groovy/fallback or scriptler, but not both
     if groovy:
@@ -319,7 +323,6 @@ def common_steps(xml_parent, element_name, REQUIRED, OPTIONAL, CHOICE_TYPE, data
     _add_element(section, 'randomName', _unique_string(data['project'], param_name))
 
 
-
 def active_choice(parser, xml_parent, data):
     """yaml: active-choice
     Creates an active choice parameter
@@ -331,17 +334,20 @@ def active_choice(parser, xml_parent, data):
     # REQUIRED: YOU MUST USE EITHER groovy or scripter, not both
     :arg hash-map groovy: the section to define the main groovy script to generate the values for this parameter
         :arg str script: the actual groovy script
-        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/...
+            or http[s]://...)
         :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
-    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main groovy fails (OPTIONAL)
+    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main
+        groovy fails (OPTIONAL)
         :arg str script: the actual fallback groovy script (REQIRED, IF you define fallback)
-        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/...
+            or http[s]://...)
         :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
     :arg hash-map scriptler: the section to define the main groovy script to generate the values for this parameter
-        :arg str script: simple file name of the scriptler script from the system library of scripts; not an 
+        :arg str script: simple file name of the scriptler script from the system library of scripts; not an
             absolute path (REQIRED, IF you define scriptler)
         :arg list parameters: list of parameters (OPTIONAL; key-value pairs)
-            :arg key-value "<KEYNAME>: <VALUE>" 
+            :arg key-value "<KEYNAME>: <VALUE>"
             ...
     arg: str choice-type: a choice type, can be on of single, multi, radio, checkbox (OPTIONAL; default single)
     arg: bool filterable: provide interactive filtering (OPTIONAL; default false)
@@ -417,22 +423,26 @@ def active_choice_reactive(parser, xml_parent, data):
     # REQUIRED: YOU MUST USE EITHER groovy or scripter, not both
     :arg hash-map groovy: the section to define the main groovy script to generate the values for this parameter
         :arg str script: the actual groovy script
-        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/...
+            or http[s]://...)
         :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
-    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main groovy fails (OPTIONAL)
+    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main
+        groovy fails (OPTIONAL)
         :arg str script: the actual fallback groovy script (REQIRED, IF you define fallback)
-        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/...
+            or http[s]://...)
         :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
     :arg hash-map scriptler: the section to define the main groovy script to generate the values for this parameter
-        :arg str script: simple file name of the scriptler script from the system library of scripts; not an 
+        :arg str script: simple file name of the scriptler script from the system library of scripts; not an
             absolute path (REQIRED, IF you define scriptler)
         :arg list parameters: list of parameters (OPTIONAL; key-value pairs)
-            :arg key-value "<KEYNAME>: <VALUE>" 
+            :arg key-value "<KEYNAME>: <VALUE>"
             ...
     arg: str choice-type: a choice type, can be on of single, multi, radio, checkbox (OPTIONAL; default single)
     arg: bool filterable: provide interactive filtering (OPTIONAL; default false)
     arg: bool filter-length: number of lines to show in the filter (OPTIONAL; default 1)
-    arg: str reference: comma-separated list of other PARAMETERS to which this one will react (OPTIONAL; but if you leave it out, what's the point?)
+    arg: str reference: comma-separated list of other PARAMETERS to which this one will react (OPTIONAL; but if you
+        leave it out, what's the point?)
     Example::
 
     .. code-block:: yaml
@@ -508,22 +518,25 @@ def active_choice_reactive_reference(parser, xml_parent, data):
     # REQUIRED: YOU MUST USE EITHER groovy or scripter, not both
     :arg hash-map groovy: the section to define the main groovy script to generate the values for this parameter
         :arg str script: the actual groovy script
-        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/...
+            or http[s]://...)
         :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
-    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main groovy fails (OPTIONAL)
+    :arg hash-map fallback: the section to define the fallback groovy script to generate the values when the main
+        groovy fails (OPTIONAL)
         :arg str script: the actual fallback groovy script (REQIRED, IF you define fallback)
-        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/... or http[s]://...)
+        :arg str classpath: additional class paths for your groovy code (OPTIONAL; URLs of the form file:/...
+            or http[s]://...)
         :arg str sandbox: run this script in a sandbox (OPTIONAL; default false)
     :arg hash-map scriptler: the section to define the main groovy script to generate the values for this parameter
-        :arg str script: simple file name of the scriptler script from the system library of scripts; not an 
+        :arg str script: simple file name of the scriptler script from the system library of scripts; not an
             absolute path (REQIRED, IF you define scriptler)
         :arg list parameters: list of parameters (OPTIONAL; key-value pairs)
-            :arg key-value "<KEYNAME>: <VALUE>" 
+            :arg key-value "<KEYNAME>: <VALUE>"
             ...
     arg: str choice-type: a choice type, can be on of single, multi, radio, checkbox (OPTIONAL; default single)
     arg: bool filterable: provide interactive filtering (OPTIONAL; default false)
     arg: bool filter-length: number of lines to show in the filter (OPTIONAL; default 1)
-    arg: str reference: comma-separated list of other PARAMETERS to which this one will react (OPTIONAL; but if you 
+    arg: str reference: comma-separated list of other PARAMETERS to which this one will react (OPTIONAL; but if you
         leave it out, what's the point?)
     Example::
 

--- a/jenkins_jobs_active_choice/active_choice.py
+++ b/jenkins_jobs_active_choice/active_choice.py
@@ -201,3 +201,16 @@ def dynamic_reference_parameter(parser, xml_parent, data):
     _add_element(section, 'choiceType', CHOICE_TYPE[data.get('choice-type', 'input-text')])
     # added calculated fields
     _add_element(section, 'randomName', _unique_string(data['project'], data['name']))
+
+
+def active_choice(parser, xml_parent, data):
+    pass
+
+
+def active_choice_reactive(parser, xml_parent, data):
+    pass
+
+
+def active_choice_reactive_reference(parser, xml_parent, data):
+    pass
+

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,10 @@ setup(
     entry_points={
         'jenkins_jobs.parameters': [
             'cascade-choice = jenkins_jobs_active_choice.active_choice:cascade_choice_parameter',
-            'active-choice = jenkins_jobs_active_choice.active_choice:cascade_choice_parameter',
-            'dynamic-reference = jenkins_jobs_active_choice.active_choice:dynamic_reference_parameter']},
+            'dynamic-reference = jenkins_jobs_active_choice.active_choice:dynamic_reference_parameter',
+            'active-choice = jenkins_jobs_active_choice.active_choice:active_choice',
+            'active-choice-reactive = jenkins_jobs_active_choice.active_choice:active_choice_reactive',
+            'active-choice-reactive-reference = jenkins_jobs_active_choice.active_choice:active_choice_reactive_reference']},
     packages=['jenkins_jobs_active_choice'],
     classifiers=[
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
             'dynamic-reference = jenkins_jobs_active_choice.active_choice:dynamic_reference_parameter',
             'active-choice = jenkins_jobs_active_choice.active_choice:active_choice',
             'active-choice-reactive = jenkins_jobs_active_choice.active_choice:active_choice_reactive',
-            'active-choice-reactive-reference = jenkins_jobs_active_choice.active_choice:active_choice_reactive_reference']},
+            'active-choice-reactive-reference = '
+            'jenkins_jobs_active_choice.active_choice:active_choice_reactive_reference']},
     packages=['jenkins_jobs_active_choice'],
     classifiers=[
         'Environment :: Console',

--- a/tests/fixtures/case-0010.xml
+++ b/tests/fixtures/case-0010.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.ChoiceParameter>
+          <name>ACTIVE_CHOICE_04</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_04 with options foo and bar.</description>
+          <visibleItemCount>1</visibleItemCount>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript>
+              <script>return ['foo:selected', 'bar']
+</script>
+              <sandbox>false</sandbox>
+            </secureScript>
+            <secureFallbackScript>
+              <script>return ['Error']
+</script>
+              <sandbox>true</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+              </classpath>
+            </secureFallbackScript>
+          </script>
+          <choiceType>PT_CHECKBOX</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_04</randomName>
+        </org.biouno.unochoice.ChoiceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0010.yaml
+++ b/tests/fixtures/case-0010.yaml
@@ -1,0 +1,33 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_04
+              description: "A parameter named ACTIVE_CHOICE_04 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+              fallback:
+                  script: |
+                      return ['Error']
+                  sandbox: true    
+                  classpath: file:/tmp/aklsdjfkl.jar
+              visible-item-count: 1
+              choice-type: checkbox
+

--- a/tests/fixtures/case-0011.xml
+++ b/tests/fixtures/case-0011.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.ChoiceParameter>
+          <name>ACTIVE_CHOICE_05</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_05 with options foo and bar.</description>
+          <visibleItemCount>1</visibleItemCount>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.ScriptlerScript">
+            <scriptlerScriptId>print-path</scriptlerScriptId>
+            <parameters class="linked-hash-map">
+              <entry>
+                <string>PARAM1</string>
+                <string>value1 alksdjflksdf lkasjflk</string>
+              </entry>
+              <entry>
+                <string>PARAM2</string>
+                <string>value2</string>
+              </entry>
+            </parameters>
+          </script>
+          <choiceType>PT_CHECKBOX</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_05</randomName>
+        </org.biouno.unochoice.ChoiceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0011.yaml
+++ b/tests/fixtures/case-0011.yaml
@@ -1,0 +1,30 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_05
+              description: "A parameter named ACTIVE_CHOICE_05 with options foo and bar."
+              scriptler:
+                  script: print-path
+                  parameters:
+                      - PARAM1:  value1 alksdjflksdf lkasjflk
+                      - PARAM2:  value2
+              visible-item-count: 1
+              choice-type: checkbox
+

--- a/tests/fixtures/case-0012.xml
+++ b/tests/fixtures/case-0012.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.CascadeChoiceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_01</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_01 with options foo and bar.</description>
+          <visibleItemCount>10</visibleItemCount>
+          <referencedParameters>STR_PARAM,CHOICE_PARAM</referencedParameters>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript>
+              <script>return ['foo:selected', 'bar']
+</script>
+              <sandbox>false</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+              </classpath>
+            </secureScript>
+            <secureFallbackScript>
+              <script>return ['Error']
+</script>
+              <sandbox>true</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+                <entry>https://lakjsdfklsdjklf/lkajsdflk.jar</entry>
+              </classpath>
+            </secureFallbackScript>
+          </script>
+          <choiceType>PT_MULTI_SELECT</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_01</randomName>
+        </org.biouno.unochoice.CascadeChoiceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0012.yaml
+++ b/tests/fixtures/case-0012.yaml
@@ -1,0 +1,35 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice-reactive:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_01
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_01 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,https://lakjsdfklsdjklf/lkajsdflk.jar
+                  sandbox: true    
+              visible-item-count: 10
+              reference: STR_PARAM,CHOICE_PARAM
+              choice-type: multi
+

--- a/tests/fixtures/case-0013.xml
+++ b/tests/fixtures/case-0013.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.CascadeChoiceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_02</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_02 with options foo and bar.</description>
+          <visibleItemCount>10</visibleItemCount>
+          <referencedParameters>STR_PARAM,ACTIVE_CHOICE_01</referencedParameters>
+          <filterable>true</filterable>
+          <filterLength>10</filterLength>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript>
+              <script>return ['foo:selected', 'bar']
+</script>
+              <sandbox>true</sandbox>
+              <classpath>
+                <entry>file:/your-path/your-classes.jar</entry>
+              </classpath>
+            </secureScript>
+          </script>
+          <choiceType>PT_RADIO</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_02</randomName>
+        </org.biouno.unochoice.CascadeChoiceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0013.yaml
+++ b/tests/fixtures/case-0013.yaml
@@ -1,0 +1,33 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice-reactive:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_02
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_02 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/your-path/your-classes.jar
+                  sandbox: true    
+              reference: STR_PARAM,ACTIVE_CHOICE_01
+              visible-item-count: 10
+              choice-type: radio
+              filterable:  true
+              filter-length:  10
+

--- a/tests/fixtures/case-0014.xml
+++ b/tests/fixtures/case-0014.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.CascadeChoiceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_03</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_03 with options foo and bar.</description>
+          <visibleItemCount>10</visibleItemCount>
+          <referencedParameters>STR_PARAM</referencedParameters>
+          <filterable>true</filterable>
+          <filterLength>4</filterLength>
+          <script class="org.biouno.unochoice.model.ScriptlerScript">
+            <scriptlerScriptId>print-path</scriptlerScriptId>
+            <parameters class="linked-hash-map">
+              <entry>
+                <string>PARAM1</string>
+                <string>value1 aklfsdj kalsjflk</string>
+              </entry>
+              <entry>
+                <string>PARAM2</string>
+                <string>value2</string>
+              </entry>
+            </parameters>
+          </script>
+          <choiceType>PT_CHECKBOX</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_03</randomName>
+        </org.biouno.unochoice.CascadeChoiceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0014.yaml
+++ b/tests/fixtures/case-0014.yaml
@@ -1,0 +1,33 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice-reactive:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_03
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_03 with options foo and bar."
+              scriptler:
+                  script: print-path
+                  parameters:
+                      - PARAM1:  value1 aklfsdj kalsjflk
+                      - PARAM2:  value2
+              reference: STR_PARAM
+              visible-item-count: 10
+              choice-type: checkbox
+              filterable:  true
+              filter-length: 4
+

--- a/tests/fixtures/case-0015.xml
+++ b/tests/fixtures/case-0015.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.CascadeChoiceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_04</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_04 with options foo and bar.</description>
+          <visibleItemCount>10</visibleItemCount>
+          <referencedParameters>STR_PARAM,CHOICE_PARAM</referencedParameters>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.ScriptlerScript">
+            <scriptlerScriptId>print-path</scriptlerScriptId>
+            <parameters class="linked-hash-map"/>
+          </script>
+          <choiceType>PT_CHECKBOX</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_04</randomName>
+        </org.biouno.unochoice.CascadeChoiceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0015.yaml
+++ b/tests/fixtures/case-0015.yaml
@@ -1,0 +1,28 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice-reactive:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_04
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_04 with options foo and bar."
+              scriptler:
+                  script: print-path
+              reference: STR_PARAM,CHOICE_PARAM
+              visible-item-count: 10
+              choice-type: checkbox
+

--- a/tests/fixtures/case-0016.xml
+++ b/tests/fixtures/case-0016.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.DynamicReferenceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_REF_01</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_REF_01 with options foo and bar.</description>
+          <visibleItemCount>1</visibleItemCount>
+          <referencedParameters>STR_PARAM</referencedParameters>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript>
+              <script>return ['foo:selected', 'bar']
+</script>
+              <sandbox>true</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+              </classpath>
+            </secureScript>
+            <secureFallbackScript>
+              <script>return ['Error']
+</script>
+              <sandbox>false</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+                <entry>http://lakjsdfklsdjklf/lkajsdflk.jar</entry>
+              </classpath>
+            </secureFallbackScript>
+          </script>
+          <choiceType>ET_TEXT_BOX</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_ref_01</randomName>
+        </org.biouno.unochoice.DynamicReferenceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0016.yaml
+++ b/tests/fixtures/case-0016.yaml
@@ -1,0 +1,35 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice-reactive-reference:
+              name: ACTIVE_CHOICE_REACTIVE_REF_01
+              project: 'active-choice-example'
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_01 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+                  sandbox: true    
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              reference: STR_PARAM
+              omit-value: false
+              choice-type: input-text
+

--- a/tests/fixtures/case-0017.xml
+++ b/tests/fixtures/case-0017.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.DynamicReferenceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_REF_02</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_REF_02 with options foo and bar.</description>
+          <visibleItemCount>1</visibleItemCount>
+          <referencedParameters>STR_PARAM,ACTIVE_CHOICE_01</referencedParameters>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript>
+              <script>return ['foo:selected', 'bar']
+</script>
+              <sandbox>true</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+              </classpath>
+            </secureScript>
+            <secureFallbackScript>
+              <script>return ['Error']
+</script>
+              <sandbox>false</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+                <entry>http://lakjsdfklsdjklf/lkajsdflk.jar</entry>
+              </classpath>
+            </secureFallbackScript>
+          </script>
+          <choiceType>ET_ORDERED_LIST</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_ref_02</randomName>
+        </org.biouno.unochoice.DynamicReferenceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0017.yaml
+++ b/tests/fixtures/case-0017.yaml
@@ -1,0 +1,35 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice-reactive-reference:
+              name: ACTIVE_CHOICE_REACTIVE_REF_02
+              project: 'active-choice-example'
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_02 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+                  sandbox: true    
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              reference: STR_PARAM,ACTIVE_CHOICE_01
+              omit-value: false
+              choice-type: numbered-list
+

--- a/tests/fixtures/case-0018.xml
+++ b/tests/fixtures/case-0018.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.DynamicReferenceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_REF_03</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_REF_03 with options foo and bar.</description>
+          <visibleItemCount>1</visibleItemCount>
+          <referencedParameters>STR_PARAM,CHOICE_PARAM</referencedParameters>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript>
+              <script>return ['foo:selected', 'bar']
+</script>
+              <sandbox>true</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+              </classpath>
+            </secureScript>
+            <secureFallbackScript>
+              <script>return ['Error']
+</script>
+              <sandbox>false</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+                <entry>http://lakjsdfklsdjklf/lkajsdflk.jar</entry>
+              </classpath>
+            </secureFallbackScript>
+          </script>
+          <choiceType>ET_UNORDERED_LIST</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_ref_03</randomName>
+        </org.biouno.unochoice.DynamicReferenceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0018.yaml
+++ b/tests/fixtures/case-0018.yaml
@@ -1,0 +1,35 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice-reactive-reference:
+              name: ACTIVE_CHOICE_REACTIVE_REF_03
+              project: 'active-choice-example'
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_03 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+                  sandbox: true    
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              reference: STR_PARAM,CHOICE_PARAM
+              omit-value: false
+              choice-type: bullet-list
+

--- a/tests/fixtures/case-0019.xml
+++ b/tests/fixtures/case-0019.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.DynamicReferenceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_REF_04</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_REF_04 with options foo and bar.</description>
+          <visibleItemCount>1</visibleItemCount>
+          <referencedParameters>STR_PARAM,CHOICE_PARAM</referencedParameters>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript>
+              <script>return ['foo:selected', 'bar']
+</script>
+              <sandbox>true</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+              </classpath>
+            </secureScript>
+            <secureFallbackScript>
+              <script>return ['Error']
+</script>
+              <sandbox>false</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+                <entry>http://lakjsdfklsdjklf/lkajsdflk.jar</entry>
+              </classpath>
+            </secureFallbackScript>
+          </script>
+          <choiceType>ET_FORMATTED_HTML</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_ref_04</randomName>
+        </org.biouno.unochoice.DynamicReferenceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0019.yaml
+++ b/tests/fixtures/case-0019.yaml
@@ -1,0 +1,35 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice-reactive-reference:
+              name: ACTIVE_CHOICE_REACTIVE_REF_04
+              project: 'active-choice-example'
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_04 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+                  sandbox: true    
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              reference: STR_PARAM,CHOICE_PARAM
+              omit-value: false
+              choice-type: formatted-html
+

--- a/tests/fixtures/case-0020.xml
+++ b/tests/fixtures/case-0020.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.DynamicReferenceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_REF_05</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_REF_05 with options foo and bar.</description>
+          <visibleItemCount>1</visibleItemCount>
+          <referencedParameters>STR_PARAM</referencedParameters>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript>
+              <script>return ['foo:selected', 'bar']
+</script>
+              <sandbox>true</sandbox>
+            </secureScript>
+            <secureFallbackScript>
+              <script>return ['Error']
+</script>
+              <sandbox>false</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+                <entry>http://lakjsdfklsdjklf/lkajsdflk.jar</entry>
+              </classpath>
+            </secureFallbackScript>
+          </script>
+          <choiceType>ET_FORMATTED_HIDDEN_HTML</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_ref_05</randomName>
+        </org.biouno.unochoice.DynamicReferenceParameter>
+        <org.biouno.unochoice.DynamicReferenceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_REF_06</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_REF_06 with options foo and bar.</description>
+          <visibleItemCount>10</visibleItemCount>
+          <referencedParameters>STR_PARAM</referencedParameters>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.ScriptlerScript">
+            <scriptlerScriptId>print-path</scriptlerScriptId>
+            <parameters class="linked-hash-map">
+              <entry>
+                <string>PARAM1</string>
+                <string>value1</string>
+              </entry>
+            </parameters>
+          </script>
+          <choiceType>ET_TEXT_BOX</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_ref_06</randomName>
+        </org.biouno.unochoice.DynamicReferenceParameter>
+        <org.biouno.unochoice.DynamicReferenceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_REF_07</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_REF_07 with options foo and bar.</description>
+          <visibleItemCount>10</visibleItemCount>
+          <referencedParameters>STR_PARAM,CHOICE_PARAM</referencedParameters>
+          <filterable>true</filterable>
+          <filterLength>8</filterLength>
+          <script class="org.biouno.unochoice.model.ScriptlerScript">
+            <scriptlerScriptId>print-path</scriptlerScriptId>
+            <parameters class="linked-hash-map"/>
+          </script>
+          <choiceType>ET_TEXT_BOX</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_ref_07</randomName>
+        </org.biouno.unochoice.DynamicReferenceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0020.yaml
+++ b/tests/fixtures/case-0020.yaml
@@ -1,0 +1,58 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice-reactive-reference:
+              name: ACTIVE_CHOICE_REACTIVE_REF_05
+              project: 'active-choice-example'
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_05 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  sandbox: true    
+              fallback:
+                  script: |
+                      return ['Error']
+                  classpath: file:/tmp/aklsdjfkl.jar,http://lakjsdfklsdjklf/lkajsdflk.jar
+              reference: STR_PARAM
+              omit-value: false
+              choice-type: formatted-hidden-html
+
+          - active-choice-reactive-reference:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_REF_06
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_06 with options foo and bar."
+              scriptler:
+                  script: print-path
+                  parameters:
+                      - PARAM1: value1
+              reference: STR_PARAM
+              visible-item-count: 10
+              choice-type: input-text 
+
+          - active-choice-reactive-reference:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_REF_07
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_07 with options foo and bar."
+              scriptler:
+                  script: print-path
+              reference: STR_PARAM,CHOICE_PARAM
+              visible-item-count: 10
+              choice-type: input-text 
+              filterable:  true
+              filter-length: 8
+

--- a/tests/fixtures/case-0021.xml
+++ b/tests/fixtures/case-0021.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.DynamicReferenceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_REF_06</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_REF_06 with options foo and bar.</description>
+          <visibleItemCount>10</visibleItemCount>
+          <referencedParameters>STR_PARAM</referencedParameters>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.ScriptlerScript">
+            <scriptlerScriptId>print-path</scriptlerScriptId>
+            <parameters class="linked-hash-map">
+              <entry>
+                <string>PARAM1</string>
+                <string>value1</string>
+              </entry>
+            </parameters>
+          </script>
+          <choiceType>ET_TEXT_BOX</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_ref_06</randomName>
+        </org.biouno.unochoice.DynamicReferenceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0021.yaml
+++ b/tests/fixtures/case-0021.yaml
@@ -1,0 +1,30 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice-reactive-reference:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_REF_06
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_06 with options foo and bar."
+              scriptler:
+                  script: print-path
+                  parameters:
+                      - PARAM1: value1
+              reference: STR_PARAM
+              visible-item-count: 10
+              choice-type: input-text 
+

--- a/tests/fixtures/case-0022.xml
+++ b/tests/fixtures/case-0022.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.DynamicReferenceParameter>
+          <name>ACTIVE_CHOICE_REACTIVE_REF_07</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_REACTIVE_REF_07 with options foo and bar.</description>
+          <visibleItemCount>10</visibleItemCount>
+          <referencedParameters>STR_PARAM,CHOICE_PARAM</referencedParameters>
+          <filterable>true</filterable>
+          <filterLength>8</filterLength>
+          <script class="org.biouno.unochoice.model.ScriptlerScript">
+            <scriptlerScriptId>print-path</scriptlerScriptId>
+            <parameters class="linked-hash-map"/>
+          </script>
+          <choiceType>ET_TEXT_BOX</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_reactive_ref_07</randomName>
+        </org.biouno.unochoice.DynamicReferenceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-0022.yaml
+++ b/tests/fixtures/case-0022.yaml
@@ -1,0 +1,30 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice-reactive-reference:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_REACTIVE_REF_07
+              description: "A parameter named ACTIVE_CHOICE_REACTIVE_REF_07 with options foo and bar."
+              scriptler:
+                  script: print-path
+              reference: STR_PARAM,CHOICE_PARAM
+              visible-item-count: 10
+              choice-type: input-text 
+              filterable:  true
+              filter-length: 8
+

--- a/tests/fixtures/case-007.xml
+++ b/tests/fixtures/case-007.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.ChoiceParameter>
+          <name>ACTIVE_CHOICE_01</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_01 with options foo and bar.</description>
+          <visibleItemCount>1</visibleItemCount>
+          <filterable>true</filterable>
+          <filterLength>3</filterLength>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript>
+              <script>return ['foo:selected', 'bar']
+</script>
+              <sandbox>false</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+              </classpath>
+            </secureScript>
+            <secureFallbackScript>
+              <script>return ['Error']
+</script>
+              <sandbox>false</sandbox>
+            </secureFallbackScript>
+          </script>
+          <choiceType>PT_SINGLE_SELECT</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_01</randomName>
+        </org.biouno.unochoice.ChoiceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-007.yaml
+++ b/tests/fixtures/case-007.yaml
@@ -1,0 +1,35 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_01
+              description: "A parameter named ACTIVE_CHOICE_01 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+                  classpath: file:/tmp/aklsdjfkl.jar
+                  sandbox: false        
+              fallback:
+                  script: |
+                      return ['Error']
+              visible-item-count: 1
+              choice-type: single
+              filterable:  true
+              filter-length: 3
+

--- a/tests/fixtures/case-008.xml
+++ b/tests/fixtures/case-008.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.ChoiceParameter>
+          <name>ACTIVE_CHOICE_02</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_02 with options foo and bar.</description>
+          <visibleItemCount>4</visibleItemCount>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript>
+              <script>return ['foo:selected', 'bar']
+</script>
+              <sandbox>false</sandbox>
+            </secureScript>
+            <secureFallbackScript>
+              <script>return ['Error']
+</script>
+              <sandbox>true</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+              </classpath>
+            </secureFallbackScript>
+          </script>
+          <choiceType>PT_MULTI_SELECT</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_02</randomName>
+        </org.biouno.unochoice.ChoiceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-008.yaml
+++ b/tests/fixtures/case-008.yaml
@@ -1,0 +1,34 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_02
+              description: "A parameter named ACTIVE_CHOICE_02 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+              fallback:
+                  script: |
+                      return ['Error']
+                  sandbox: true    
+                  classpath: file:/tmp/aklsdjfkl.jar
+              visible-item-count: 4
+              choice-type: multi
+              filterable:  false
+

--- a/tests/fixtures/case-009.xml
+++ b/tests/fixtures/case-009.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>STR_PARAM</name>
+          <description/>
+          <defaultValue>test</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CHOICE_PARAM</name>
+          <description>Just a test parameter for used by references
+</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>choice_01</string>
+              <string>choice_02</string>
+              <string>choice_03</string>
+              <string>choice_04</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <org.biouno.unochoice.ChoiceParameter>
+          <name>ACTIVE_CHOICE_03</name>
+          <projectName>active-choice-example</projectName>
+          <description>A parameter named ACTIVE_CHOICE_03 with options foo and bar.</description>
+          <visibleItemCount>3</visibleItemCount>
+          <filterable>false</filterable>
+          <filterLength>1</filterLength>
+          <script class="org.biouno.unochoice.model.GroovyScript">
+            <secureScript>
+              <script>return ['foo:selected', 'bar']
+</script>
+              <sandbox>false</sandbox>
+            </secureScript>
+            <secureFallbackScript>
+              <script>return ['Error']
+</script>
+              <sandbox>true</sandbox>
+              <classpath>
+                <entry>file:/tmp/aklsdjfkl.jar</entry>
+              </classpath>
+            </secureFallbackScript>
+          </script>
+          <choiceType>PT_RADIO</choiceType>
+          <parameters class="linked-hash-map"/>
+          <randomName>choice-param-active-choice-example-active_choice_03</randomName>
+        </org.biouno.unochoice.ChoiceParameter>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/fixtures/case-009.yaml
+++ b/tests/fixtures/case-009.yaml
@@ -1,0 +1,33 @@
+  - job:
+      name: 'TEST-jjb-active-choice'
+
+      parameters:
+          - string:
+              name: STR_PARAM
+              default: test
+
+          - choice:
+              name: CHOICE_PARAM
+              choices:
+                - choice_01
+                - choice_02
+                - choice_03
+                - choice_04
+              description: |
+                Just a test parameter for used by references
+
+          - active-choice:
+              project: 'active-choice-example'
+              name: ACTIVE_CHOICE_03
+              description: "A parameter named ACTIVE_CHOICE_03 with options foo and bar."
+              groovy:
+                  script: |
+                      return ['foo:selected', 'bar']
+              fallback:
+                  script: |
+                      return ['Error']
+                  sandbox: true    
+                  classpath: file:/tmp/aklsdjfkl.jar
+              visible-item-count: 3
+              choice-type: radio
+


### PR DESCRIPTION
Added full support for Active Choices Plug-in while (mostly) maintaining backwards compatibility (active-choice is no longer an alias for cascade-choice).

New entry points are:

* active-choice
* active-choice-reactive
* active-choice-reactive-reference
